### PR TITLE
fix: install typesync on postinstall #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Auto install typings for your package dependencies",
   "main": "index.js",
   "bin": {
-    "install-types": "./index.js"
+    "install-types": "./index.js",
+    "postinstall": "npm i typesync -g"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",


### PR DESCRIPTION
Install `typesync` on post-install, so that the cli is available globally.

Should resolve - https://github.com/ClearTax/install-types/issues/2